### PR TITLE
Implement BcMath

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
   "require-dev": {
     "phpbench/phpbench": "^0.13.0",
     "phpstan/phpstan": "^0.9.0",
-    "phpunit/phpunit": "^5.3"
+    "phpunit/phpunit": "^5.3",
+    "ext-bcmath": "*"
+  },
+  "suggest": {
+    "ext-bcmath": "Allows you to do math with big numbers"
   },
   "autoload": {
     "psr-4": {

--- a/src/BasicMoney.php
+++ b/src/BasicMoney.php
@@ -48,11 +48,11 @@ final class BasicMoney extends MoneyProvider
 
         if ($displayCountryForUS && $this->currency === 'USD') {
             if ($this->amount >= 0) {
-                return 'US' . $formatter->formatCurrency($this->amount, $this->currency);
+                return 'US' . $formatter->formatCurrency((float)$this->amount, $this->currency);
             }
-            return '-US' . $formatter->formatCurrency(-$this->amount, $this->currency);
+            return '-US' . $formatter->formatCurrency((float)(-$this->amount), $this->currency);
         }
-        return $formatter->formatCurrency($this->amount, $this->currency);
+        return $formatter->formatCurrency((float)$this->amount, $this->currency);
     }
 
     /**

--- a/src/BasicMoney.php
+++ b/src/BasicMoney.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace Votemike\Money;
+
+
+use InvalidArgumentException;
+use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
+
+final class BasicMoney extends MoneyProvider
+{
+
+    public function abs(): Money
+    {
+        return new Money(abs($this->amount), $this->currency);
+    }
+
+    public function add(Money $money): Money
+    {
+        $this->assertCurrencyMatches($money);
+
+        return new Money($this->amount + $money->getAmount(), $this->currency);
+    }
+
+    /**
+     * @param float $operator
+     *
+     * @return Money
+     */
+    public function divide(float $operator): Money
+    {
+        if ($operator == 0) {
+            throw new InvalidArgumentException('Cannot divide by zero');
+        }
+        return new Money($this->amount / $operator, $this->currency);
+    }
+
+    /**
+     * Returns a rounded string with the currency symbol
+     *
+     * @param bool $displayCountryForUS Set to true if you would like 'US$' instead of just '$'
+     *
+     * @return string
+     */
+    public function format(bool $displayCountryForUS = false): string
+    {
+        $formatter = new NumberFormatter('en', NumberFormatter::CURRENCY);
+
+        if ($displayCountryForUS && $this->currency === 'USD') {
+            if ($this->amount >= 0) {
+                return 'US' . $formatter->formatCurrency($this->amount, $this->currency);
+            }
+            return '-US' . $formatter->formatCurrency(-$this->amount, $this->currency);
+        }
+        return $formatter->formatCurrency($this->amount, $this->currency);
+    }
+
+    /**
+     * Returns a rounded number without currency
+     * If the number is negative, the currency is within parentheses
+     */
+    public function formatForAccounting(): string
+    {
+        $amount = $this->getRoundedAmount();
+        $negative = 0 > $amount;
+        if ($negative) {
+            $amount *= -1;
+        }
+        $amount = number_format($amount, Intl::getCurrencyBundle()->getFractionDigits($this->currency));
+        return $negative ? '(' . $amount . ')' : $amount;
+    }
+
+    /**
+     * Returns a string consisting of the currency symbol, a rounded int and a suffix
+     * e.g. $33k instead of $3321.12
+     */
+    public function formatShorthand(): string
+    {
+        $amount = $this->amount;
+        $negative = 0 > $amount;
+        if ($negative) {
+            $amount *= -1;
+        }
+        $units = ['', 'k', 'm', 'bn', 'tn'];
+        $power = $amount > 0 ? floor(log(round($amount), 1000)) : 0;
+        $ret = Intl::getCurrencyBundle()->getCurrencySymbol($this->currency, 'en').round($amount / pow(1000, $power), 0). $units[$power];
+        return $negative ? '-'.$ret : $ret;
+    }
+
+    /**
+     * The same as format() except that positive numbers always include the + sign
+     *
+     * @param bool $displayCountryForUS Set to true if you would like 'US$' instead of just '$'
+     *
+     * @return string
+     */
+    public function formatWithSign(bool $displayCountryForUS = false): string
+    {
+        $string = $this->format($displayCountryForUS);
+
+        if ($this->amount <= 0) {
+            return $string;
+        }
+
+        return '+' . $string;
+    }
+
+    /**
+     * Returns the amount rounded to the correct number of decimal places for that currency
+     */
+    public function getRoundedAmount(): float
+    {
+        $fractionDigits = Intl::getCurrencyBundle()->getFractionDigits($this->currency);
+        $roundingIncrement = Intl::getCurrencyBundle()->getRoundingIncrement($this->currency);
+
+        $value = round($this->amount, $fractionDigits);
+
+        // Swiss rounding
+        if (0 < $roundingIncrement && 0 < $fractionDigits) {
+            $roundingFactor = $roundingIncrement / pow(10, $fractionDigits);
+            $value = round($value / $roundingFactor) * $roundingFactor;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Invert the amount
+     */
+    public function inv(): Money
+    {
+        return new Money(-$this->amount, $this->currency);
+    }
+
+    /**
+     * @param float $operator
+     *
+     * @return Money
+     */
+    public function multiply($operator): Money
+    {
+        return new Money($this->amount * $operator, $this->currency);
+    }
+
+    /**
+     * A number between 0 and 100
+     *
+     * @param float $percentage
+     *
+     * @return Money
+     */
+    public function percentage($percentage): Money
+    {
+        return new Money(($this->amount * $percentage) / 100, $this->currency);
+    }
+
+    /**
+     * @param Money $money
+     *
+     * @return Money
+     */
+    public function sub(Money $money) : Money
+    {
+        $this->assertCurrencyMatches($money);
+
+        return new Money($this->amount - $money->getAmount(), $this->currency);
+    }
+}

--- a/src/BasicMoney.php
+++ b/src/BasicMoney.php
@@ -27,7 +27,7 @@ final class BasicMoney extends MoneyProvider
      *
      * @return Money
      */
-    public function divide(float $operator): Money
+    public function divide($operator): Money
     {
         if ($operator == 0) {
             throw new InvalidArgumentException('Cannot divide by zero');

--- a/src/BasicMoney.php
+++ b/src/BasicMoney.php
@@ -2,14 +2,12 @@
 
 namespace Votemike\Money;
 
-
 use InvalidArgumentException;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
 
 final class BasicMoney extends MoneyProvider
 {
-
     public function abs(): Money
     {
         return new Money(abs($this->amount), $this->currency);

--- a/src/BcMathMoney.php
+++ b/src/BcMathMoney.php
@@ -2,14 +2,12 @@
 
 namespace Votemike\Money;
 
-
 use InvalidArgumentException;
 use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
 
 final class BcMathMoney extends MoneyProvider
 {
-
     public function abs(): Money
     {
         if (bccomp($this->amount, 0) === -1) {
@@ -58,7 +56,6 @@ final class BcMathMoney extends MoneyProvider
         $formatter = new NumberFormatter('en', NumberFormatter::CURRENCY);
 
         if ($displayCountryForUS && $this->currency === 'USD') {
-
             if (bccomp($this->amount, 0) >= 0) {
                 return 'US' . $formatter->formatCurrency((float)$this->amount, $this->currency);
             }
@@ -100,11 +97,11 @@ final class BcMathMoney extends MoneyProvider
             if ($power > 1) {
                 $amount = self::bcround(bcdiv($amount, bcpow(10, $power), $power));
                 $unitIndex = $power / 3;
-            }else {
+            } else {
                 $unitIndex = 0;
             }
             $unit = ['', 'k', 'm', 'bn', 'tn'][$unitIndex];
-        }else {
+        } else {
             $unit = '';
         }
         return
@@ -112,7 +109,6 @@ final class BcMathMoney extends MoneyProvider
             Intl::getCurrencyBundle()->getCurrencySymbol($this->currency, 'en').
             $amount.
             $unit;
-
     }
 
     /**
@@ -204,8 +200,12 @@ final class BcMathMoney extends MoneyProvider
     private static function bcfloor($number)
     {
         if (strpos($number, '.') !== false) {
-            if (preg_match("~\.[0]+$~", $number)) return self::bcround($number, 0);
-            if ($number[0] != '-') return bcadd($number, 0, 0);
+            if (preg_match("~\.[0]+$~", $number)) {
+                return self::bcround($number, 0);
+            }
+            if ($number[0] != '-') {
+                return bcadd($number, 0, 0);
+            }
             return bcsub($number, 1, 0);
         }
         return $number;
@@ -227,7 +227,6 @@ final class BcMathMoney extends MoneyProvider
         while (count($digits) > $precision) {
             $lastChar = array_pop($digits);
             if ($lastChar >= 5) {
-
                 $position = 1;
                 $resolved = false;
                 while (!$resolved) {
@@ -245,12 +244,11 @@ final class BcMathMoney extends MoneyProvider
                     if ($digit === 10) {
                         $digit = 0;
                         $position++;
-                    }else {
+                    } else {
                         $resolved = true;
                     }
                     unset($digit);
                 }
-
             }
         }
 
@@ -264,7 +262,7 @@ final class BcMathMoney extends MoneyProvider
         if (strpos($number, '.') === false) {
             return 0;
         }
-        list ($left, $right) = explode('.', $number);
+        list($left, $right) = explode('.', $number);
         return strlen($right);
     }
 }

--- a/src/BcMathMoney.php
+++ b/src/BcMathMoney.php
@@ -60,12 +60,12 @@ final class BcMathMoney extends MoneyProvider
         if ($displayCountryForUS && $this->currency === 'USD') {
 
             if (bccomp($this->amount, 0) >= 0) {
-                return 'US' . $formatter->formatCurrency($this->amount, $this->currency);
+                return 'US' . $formatter->formatCurrency((float)$this->amount, $this->currency);
             }
-            return '-US' . $formatter->formatCurrency(-$this->amount, $this->currency);
+            return '-US' . $formatter->formatCurrency((float)(-$this->amount), $this->currency);
         }
 
-        return $formatter->formatCurrency($this->amount, $this->currency);
+        return $formatter->formatCurrency((float)$this->amount, $this->currency);
     }
 
     /**
@@ -204,7 +204,7 @@ final class BcMathMoney extends MoneyProvider
     private static function bcfloor($number)
     {
         if (strpos($number, '.') !== false) {
-            if (preg_match("~\.[0]+$~", $number)) return bcround($number, 0);
+            if (preg_match("~\.[0]+$~", $number)) return self::bcround($number, 0);
             if ($number[0] != '-') return bcadd($number, 0, 0);
             return bcsub($number, 1, 0);
         }

--- a/src/BcMathMoney.php
+++ b/src/BcMathMoney.php
@@ -26,11 +26,11 @@ final class BcMathMoney extends MoneyProvider
     }
 
     /**
-     * @param float $operator
+     * @param float|string $operator
      *
      * @return Money
      */
-    public function divide(float $operator): Money
+    public function divide($operator): Money
     {
         if (bccomp($operator, 0) === 0) {
             throw new InvalidArgumentException('Cannot divide by zero');

--- a/src/BcMathMoney.php
+++ b/src/BcMathMoney.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Votemike\Money;
+
+
+use InvalidArgumentException;
+use Symfony\Component\Intl\Intl;
+use Symfony\Component\Intl\NumberFormatter\NumberFormatter;
+
+final class BcMathMoney extends MoneyProvider
+{
+
+    public function abs(): Money
+    {
+        if (bccomp($this->amount, 0) === -1) {
+            return $this->inv();
+        }
+        return new Money($this->amount, $this->currency);
+    }
+
+    public function add(Money $money): Money
+    {
+        $this->assertCurrencyMatches($money);
+
+        return new Money(bcadd($this->amount, $money->getAmount()), $this->currency);
+    }
+
+    /**
+     * @param float $operator
+     *
+     * @return Money
+     */
+    public function divide(float $operator): Money
+    {
+        if (bccomp($operator, 0) === 0) {
+            throw new InvalidArgumentException('Cannot divide by zero');
+        }
+        return new Money(
+            bcdiv(
+                $this->amount,
+                $operator,
+                Intl::getCurrencyBundle()
+                    ->getFractionDigits($this->currency)
+            ),
+            $this->currency
+        );
+    }
+
+    /**
+     * Returns a rounded string with the currency symbol
+     *
+     * @param bool $displayCountryForUS Set to true if you would like 'US$' instead of just '$'
+     *
+     * @return string
+     */
+    public function format(bool $displayCountryForUS = false): string
+    {
+        $formatter = new NumberFormatter('en', NumberFormatter::CURRENCY);
+
+        if ($displayCountryForUS && $this->currency === 'USD') {
+
+            if (bccomp($this->amount, 0) >= 0) {
+                return 'US' . $formatter->formatCurrency($this->amount, $this->currency);
+            }
+            return '-US' . $formatter->formatCurrency(-$this->amount, $this->currency);
+        }
+
+        return $formatter->formatCurrency($this->amount, $this->currency);
+    }
+
+    /**
+     * Returns a rounded number without currency
+     * If the number is negative, the currency is within parentheses
+     */
+    public function formatForAccounting(): string
+    {
+        $amount = $this->getRoundedAmount();
+        $negative = (bccomp($amount, 0) === -1);
+        if ($negative) {
+            $amount = bcmul($amount, -1, static::bcscale($amount));
+        }
+        $amount = number_format($amount, Intl::getCurrencyBundle()->getFractionDigits($this->currency));
+        return $negative ? '(' . $amount . ')' : $amount;
+    }
+
+    /**
+     * Returns a string consisting of the currency symbol, a rounded int and a suffix
+     * e.g. $33k instead of $3321.12
+     */
+    public function formatShorthand(): string
+    {
+        $amount = self::bcround($this->amount);
+        $negative = (bccomp($amount, 0) === -1);
+        if ($negative) {
+            $amount = bcmul($amount, -1);
+        }
+        if ($amount) {
+            $power = self::bcfloor(log10($amount));
+            $power -= $power % 3; // get nearest thousand power
+            if ($power > 1) {
+                $amount = self::bcround(bcdiv($amount, bcpow(10, $power), $power));
+                $unitIndex = $power / 3;
+            }else {
+                $unitIndex = 0;
+            }
+            $unit = ['', 'k', 'm', 'bn', 'tn'][$unitIndex];
+        }else {
+            $unit = '';
+        }
+        return
+            ($negative ? '-' : '').
+            Intl::getCurrencyBundle()->getCurrencySymbol($this->currency, 'en').
+            $amount.
+            $unit;
+
+    }
+
+    /**
+     * The same as format() except that positive numbers always include the + sign
+     *
+     * @param bool $displayCountryForUS Set to true if you would like 'US$' instead of just '$'
+     *
+     * @return string
+     */
+    public function formatWithSign(bool $displayCountryForUS = false): string
+    {
+        $string = $this->format($displayCountryForUS);
+
+        if (bccomp($this->amount, 0) !== 1) {
+            return $string;
+        }
+
+        return '+' . $string;
+    }
+
+    /**
+     * Returns the amount rounded to the correct number of decimal places for that currency
+     */
+    public function getRoundedAmount(): float
+    {
+        $fractionDigits = Intl::getCurrencyBundle()->getFractionDigits($this->currency);
+        $roundingIncrement = Intl::getCurrencyBundle()->getRoundingIncrement($this->currency);
+
+        $value = self::bcround($this->amount, $fractionDigits);
+
+        // Swiss rounding
+        if (0 < $roundingIncrement && 0 < $fractionDigits) {
+            $roundingFactor = $roundingIncrement / pow(10, $fractionDigits);
+            $value = bcmul(self::bcround(bcdiv($value, $roundingFactor)), $roundingFactor);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Invert the amount
+     */
+    public function inv(): Money
+    {
+        return $this->multiply(-1);
+    }
+
+    /**
+     * @param float $operator
+     *
+     * @return Money
+     */
+    public function multiply($operator): Money
+    {
+        return new Money(
+            bcmul(
+                $this->amount,
+                $operator,
+                max(self::bcscale($this->amount), self::bcscale($operator))
+            ),
+            $this->currency
+        );
+    }
+
+    /**
+     * A number between 0 and 100
+     *
+     * @param float $percentage
+     *
+     * @return Money
+     */
+    public function percentage($percentage): Money
+    {
+        return $this->multiply($percentage / 100);
+    }
+
+    /**
+     * @param Money $money
+     *
+     * @return Money
+     */
+    public function sub(Money $money) : Money
+    {
+        $this->assertCurrencyMatches($money);
+
+        return new Money(bcsub($this->amount, $money->getAmount()), $this->currency);
+    }
+
+    private static function bcfloor($number)
+    {
+        if (strpos($number, '.') !== false) {
+            if (preg_match("~\.[0]+$~", $number)) return bcround($number, 0);
+            if ($number[0] != '-') return bcadd($number, 0, 0);
+            return bcsub($number, 1, 0);
+        }
+        return $number;
+    }
+
+    private static function bcround($number, $precision = 0)
+    {
+        if (strpos($number, '.') === false) {
+            return $number;
+        }
+
+        list($left, $right) = explode('.', $number);
+
+        // we don't care about the full number
+        $right = substr($right, 0, $precision + 1);
+
+        $digits = str_split($right);
+
+        while (count($digits) > $precision) {
+            $lastChar = array_pop($digits);
+            if ($lastChar >= 5) {
+
+                $position = 1;
+                $resolved = false;
+                while (!$resolved) {
+
+                    // We went all the way up.
+                    if ((count($digits) - $position) < 0) {
+                        if ($left[0] === '-') {
+                            return $lastChar >= 5 ? $left - 1 : $left;
+                        }
+                        return $left + 1;
+                    }
+
+                    $digit =& $digits[count($digits) - $position];
+                    $digit++;
+                    if ($digit === 10) {
+                        $digit = 0;
+                        $position++;
+                    }else {
+                        $resolved = true;
+                    }
+                    unset($digit);
+                }
+
+            }
+        }
+
+        $right = implode('', $digits);
+
+        return "{$left}".($right ? ".{$right}" : '');
+    }
+
+    private static function bcscale($number): int
+    {
+        if (strpos($number, '.') === false) {
+            return 0;
+        }
+        list ($left, $right) = explode('.', $number);
+        return strlen($right);
+    }
+}

--- a/src/Money.php
+++ b/src/Money.php
@@ -1,6 +1,5 @@
 <?php namespace Votemike\Money;
 
-
 class Money implements MoneyInterface
 {
 
@@ -17,7 +16,7 @@ class Money implements MoneyInterface
     {
         if (extension_loaded('bcmath')) {
             $this->provider = new BcMathMoney($amount, $currency);
-        }else {
+        } else {
             $this->provider = new BasicMoney($amount, $currency);
         }
     }
@@ -167,5 +166,4 @@ class Money implements MoneyInterface
     {
         return $this->provider->sub($money);
     }
-
 }

--- a/src/Money.php
+++ b/src/Money.php
@@ -44,7 +44,7 @@ class Money implements MoneyInterface
      * @param float $operator
      * @return static
      */
-    public function divide(float $operator): Money
+    public function divide($operator): Money
     {
         return $this->provider->divide($operator);
     }

--- a/src/MoneyInterface.php
+++ b/src/MoneyInterface.php
@@ -11,10 +11,10 @@ interface MoneyInterface
     public function add(Money $money): Money;
 
     /**
-     * @param float $operator
+     * @param float|string $operator
      * @return Money
      */
-    public function divide(float $operator): Money;
+    public function divide($operator): Money;
 
     /**
      * Returns a rounded string with the currency symbol

--- a/src/MoneyInterface.php
+++ b/src/MoneyInterface.php
@@ -44,7 +44,10 @@ interface MoneyInterface
      */
     public function formatWithSign(bool $displayCountryForUS = false): string;
 
-    public function getAmount(): float;
+    /**
+     * @return float|int|string
+     */
+    public function getAmount();
 
     public function getCurrency(): string;
 

--- a/src/MoneyInterface.php
+++ b/src/MoneyInterface.php
@@ -2,10 +2,8 @@
 
 namespace Votemike\Money;
 
-
 interface MoneyInterface
 {
-
     public function abs(): Money;
 
     public function add(Money $money): Money;
@@ -98,5 +96,4 @@ interface MoneyInterface
      * @return Money
      */
     public function sub(Money $money): Money;
-
 }

--- a/src/MoneyInterface.php
+++ b/src/MoneyInterface.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Votemike\Money;
+
+
+interface MoneyInterface
+{
+
+    public function abs(): Money;
+
+    public function add(Money $money): Money;
+
+    /**
+     * @param float $operator
+     * @return Money
+     */
+    public function divide(float $operator): Money;
+
+    /**
+     * Returns a rounded string with the currency symbol
+     *
+     * @param bool $displayCountryForUS Set to true if you would like 'US$' instead of just '$'
+     * @return string
+     */
+    public function format(bool $displayCountryForUS = false): string;
+
+    /**
+     * Returns a rounded number without currency
+     * If the number is negative, the currency is within parentheses
+     */
+    public function formatForAccounting(): string;
+
+    /**
+     * Returns a string consisting of the currency symbol, a rounded int and a suffix
+     * e.g. $33k instead of $3321.12
+     */
+    public function formatShorthand(): string;
+
+    /**
+     * The same as format() except that positive numbers always include the + sign
+     *
+     * @param bool $displayCountryForUS Set to true if you would like 'US$' instead of just '$'
+     * @return string
+     */
+    public function formatWithSign(bool $displayCountryForUS = false): string;
+
+    public function getAmount(): float;
+
+    public function getCurrency(): string;
+
+    /**
+     * Returns the amount rounded to the correct number of decimal places for that currency
+     */
+    public function getRoundedAmount(): float;
+
+    /**
+     * Invert the amount
+     */
+    public function inv(): Money;
+
+    /**
+     * @param float $operator
+     * @return Money
+     */
+    public function multiply($operator): Money;
+
+    /**
+     * A number between 0 and 100
+     *
+     * @param float $percentage
+     * @return Money
+     */
+    public function percentage($percentage): Money;
+
+    /**
+     * Returns rounded clone of Money object, rounded to the correct number of decimal places for that currency
+     */
+    public function round(): Money;
+
+    /**
+     * Pass in an array of percentages to allocate Money in those amounts.
+     * Final entry in array gets any remaining units.
+     * If the percentages total less than 100, remaining money is allocated to an extra return value.
+     *
+     * By default, the amounts are rounded to the correct number of decimal places for that currency. This can be disabled by passing false as the second argument.
+     *
+     * @param float[] $percentages An array of percentages that must total 100 or less
+     * @param bool $round
+     * @return Money[]
+     */
+    public function split(array $percentages, bool $round = true): array;
+
+    /**
+     * @param Money $money
+     * @return Money
+     */
+    public function sub(Money $money): Money;
+
+}

--- a/src/MoneyProvider.php
+++ b/src/MoneyProvider.php
@@ -11,7 +11,7 @@ abstract class MoneyProvider implements MoneyInterface
 {
 
     /**
-     * @var float|string
+     * @var float|int|string
      */
     protected $amount;
 
@@ -53,7 +53,7 @@ abstract class MoneyProvider implements MoneyInterface
         }
     }
 
-    final public function getAmount(): float
+    final public function getAmount()
     {
         return $this->amount;
     }

--- a/src/MoneyProvider.php
+++ b/src/MoneyProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Votemike\Money;
+
+
+use DomainException;
+use InvalidArgumentException;
+use Symfony\Component\Intl\Intl;
+
+abstract class MoneyProvider implements MoneyInterface
+{
+
+    /**
+     * @var float|string
+     */
+    protected $amount;
+
+    /**
+     * @var string
+     */
+    protected $currency;
+
+    /**
+     * @param float|int|string $amount
+     * @param string $currency
+     */
+    final public function __construct($amount, string $currency)
+    {
+        if (!is_numeric($amount)) {
+            throw new InvalidArgumentException('Money only accepts numeric amounts');
+        }
+
+        if (!array_key_exists($currency, Intl::getCurrencyBundle()->getCurrencyNames())) {
+            throw new InvalidArgumentException($currency . ' is not a supported currency');
+        }
+
+        $this->amount = $amount;
+        $this->currency = $currency;
+    }
+
+    final public function __toString(): string
+    {
+        return $this->format();
+    }
+
+    /**
+     * @param Money $money
+     */
+    protected function assertCurrencyMatches(Money $money)
+    {
+        if ($this->currency !== $money->getCurrency()) {
+            throw new DomainException('Currencies must match');
+        }
+    }
+
+    final public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    final public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    /**
+     * Returns rounded clone of Money object, rounded to the correct number of decimal places for that currency
+     */
+    public function round(): Money
+    {
+        return new Money($this->getRoundedAmount(), $this->currency);
+    }
+
+    /**
+     * Pass in an array of percentages to allocate Money in those amounts.
+     * Final entry in array gets any remaining units.
+     * If the percentages total less than 100, remaining money is allocated to an extra return value.
+     *
+     * By default, the amounts are rounded to the correct number of decimal places for that currency. This can be disabled by passing false as the second argument.
+     *
+     * @param float[] $percentages An array of percentages that must total 100 or less
+     * @param bool    $round
+     *
+     * @return Money[]
+     */
+    public function split(array $percentages, bool $round = true): array
+    {
+        $totalPercentage = array_sum($percentages);
+        if ($totalPercentage > 100) {
+            throw new InvalidArgumentException('Only 100% can be allocated');
+        }
+        $amounts = [];
+        $total = 0;
+        if (!$round) {
+            foreach ($percentages as $percentage) {
+                $share = $this->percentage($percentage);
+                $total += $share->getAmount();
+                $amounts[] = $share;
+            }
+            if ($totalPercentage != 100) {
+                $amounts[] = new Money($this->amount - $total, $this->currency);
+            }
+            return $amounts;
+        }
+
+        $count = 0;
+
+        if ($totalPercentage != 100) {
+            $percentages[] = 0; //Dummy record to trigger the rest of the amount being assigned to a final pot
+        }
+
+        foreach ($percentages as $percentage) {
+            ++$count;
+            if ($count == count($percentages)) {
+                $amounts[] = new Money($this->amount - $total, $this->currency);
+            } else {
+                $share = $this->percentage($percentage)->round();
+                $total += $share->getAmount();
+                $amounts[] = $share;
+            }
+        }
+
+        return $amounts;
+    }
+
+}

--- a/src/MoneyProvider.php
+++ b/src/MoneyProvider.php
@@ -2,7 +2,6 @@
 
 namespace Votemike\Money;
 
-
 use DomainException;
 use InvalidArgumentException;
 use Symfony\Component\Intl\Intl;
@@ -122,5 +121,4 @@ abstract class MoneyProvider implements MoneyInterface
 
         return $amounts;
     }
-
 }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -415,7 +415,7 @@ class MoneyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('$78bn', $money->formatShorthand());
         $this->assertEquals('-$78bn', $money->inv()->formatShorthand());
 
-        $money = new Money(333377777777777.333, 'USD');
+        $money = new Money('333377777777777.333', 'USD');
         $this->assertEquals('$333tn', $money->formatShorthand());
         $this->assertEquals('-$333tn', $money->inv()->formatShorthand());
     }


### PR DESCRIPTION
This is in reference to issue #8.

Lots of changes. Don't look too close or your eyes will bleed. I 100% expect StyleCi errors, ill take care of those tomorrow when I am more awake. All the tests passed locally though, so that's a plus.

The TL;DR of the changes is that there are now two Money "providers." One is the same as the existing functionality, the second uses BcMath functions. When creating a new Money instance it checks to see if the BcMath extension is loaded and loads the proper provider.

My heart wont be broken if this does not get accepted. I got a bit carried away. The only reason I finished at all is because I was not going to let rounding errors win.